### PR TITLE
feat: add title to fzf picker for consistency with original windows

### DIFF
--- a/lua/ecolog/integrations/fzf.lua
+++ b/lua/ecolog/integrations/fzf.lua
@@ -252,11 +252,14 @@ function FzfPicker:open()
   self:save_current_window()
   local results = self:format_env_vars()
 
+  local current_file = require("ecolog").get_state().selected_env_file
+  local file = current_file and vim.fn.fnamemodify(current_file, ":t")
+
   fzf.fzf_exec(results, {
     winopts = {
       title = "Environment Variables",
     },
-    prompt = "> ",
+    prompt = (file or "") .. "> ",
     actions = self:create_actions(),
     fzf_opts = {
       ["--ansi"] = "",

--- a/lua/ecolog/integrations/fzf.lua
+++ b/lua/ecolog/integrations/fzf.lua
@@ -253,7 +253,10 @@ function FzfPicker:open()
   local results = self:format_env_vars()
 
   fzf.fzf_exec(results, {
-    prompt = "Environment Variables> ",
+    winopts = {
+      title = "Environment Variables",
+    },
+    prompt = "> ",
     actions = self:create_actions(),
     fzf_opts = {
       ["--ansi"] = "",


### PR DESCRIPTION
Before changes:
<img width="232" height="80" alt="Screenshot 2025-08-10 at 09 07 33" src="https://github.com/user-attachments/assets/818c718e-2201-46dc-bd40-7457a416e732" />
After changes:
<img width="232" height="80" alt="Screenshot 2025-08-10 at 09 06 58" src="https://github.com/user-attachments/assets/1d238505-0f43-4c15-9b35-48e9ab0d0c3e" />
Original pickers:
<img width="232" height="80" alt="Screenshot 2025-08-10 at 09 12 46" src="https://github.com/user-attachments/assets/0c2c10c3-1243-4826-80a4-5bb77e8c9579" />
